### PR TITLE
Fix Marquee looping bug

### DIFF
--- a/src/components/aboutSections/s2-origin.tsx
+++ b/src/components/aboutSections/s2-origin.tsx
@@ -44,6 +44,10 @@ const CircleContainer = styled.div`
     top: 22%;
     transform: translate(-50%);
     left: 54%;
+    white-space: nowrap;
+    svg {
+        display: unset;
+    };
 `;
 
 const Track = styled.div`
@@ -83,7 +87,7 @@ const S2Origin = () => {
             >
                 <Austria className="absolute" />
                 <CircleContainer>
-                    <Marquee>
+                    <Marquee delay={0} childMargin={0}>
                         <StyledWbytMarquee />
                     </Marquee>
                 </CircleContainer>


### PR DESCRIPTION
The Marquee in the origin section of the homepage didn't loop smoothly because the svgs were stacked vertically instead of horizontally due to tailwindcss displaying them as blocks instead of inline, which the library (which was designed for looping text) expected.